### PR TITLE
[GITHUB] remove -q flag for git fetch artifacts

### DIFF
--- a/bin/checkout-artifacts.sh
+++ b/bin/checkout-artifacts.sh
@@ -15,13 +15,24 @@ if [ -d $ARTIFACTS_DIR ]; then
   fi
 fi
 
-if [ ! -d $ARTIFACTS_DIR/.git ]; then 
+if [ ! -d $ARTIFACTS_DIR/.git ]; then
   rm -rf $ARTIFACTS_DIR
   git init $ARTIFACTS_DIR
 fi
 
+ARTIFACTS_LOCATION="https://github.com/ochameau/ff-dt.git artifacts-$BRANCH"
+
+echo "Now downloading test dependencies via git ($ARTIFACTS_LOCATION)."
+
+if [ $CI ]; then
+  # Silence logs when running on CI.
+  QUIET=-q
+else
+  QUIET=
+fi
+
 pushd $ARTIFACTS_DIR > /dev/null
-git fetch https://github.com/ochameau/ff-dt.git artifacts-$BRANCH -q
+git fetch $ARTIFACTS_LOCATION $QUIET
 git checkout $SHA
 popd > /dev/null
 


### PR DESCRIPTION
`git fetch https://github.com/ochameau/ff-dt.git artifacts-$BRANCH` downloads ~100MBs and can really take a lot of time depending on your connection. It should not be silenced.

Long term I don't think we should have the artifacts as a branch of the main repo. It forces contributors to do a clone singlebranch instead of the default clone.