### PR TITLE
Avoid running tests twice on pull request from ff-dt branches.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -20,8 +20,58 @@ tasks:
     extra:
       github:
         events:
+          - pull_request.opened
           - pull_request.synchronize
+    payload:
+      env:
+        GITHUB_HEAD_USER_EMAIL: "{{ event.head.user.email }}"
+        GITHUB_HEAD_REPO_URL: "{{ event.head.repo.url }}"
+        GITHUB_HEAD_REPO_SHA: "{{ event.head.sha }}"
+        GITHUB_HEAD_REPO_BRANCH: "{{ event.head.repo.branch }}"
+      maxRunTime: 600
+      image: 'node:6'
+# taskclusterProxy is required to implement a decision task
+      features:
+        taskclusterProxy: true
+      command:
+        - "/bin/bash"
+        - "-cx"
+        - >
+          git clone {{event.head.repo.url}} -q --depth 1 --branch {{ event.head.repo.branch }} devtools &&
+          cd devtools &&
+          git checkout -q {{event.head.sha}} &&
+          cd bin/taskcluster &&
+          npm install --silent &&
+          nodejs task_decision.js
+    metadata:
+      name: task-decision
+      description: "Manage tasks"
+      owner: "{{ event.head.user.email }}"
+      source: "{{ event.head.repo.url }}"
+# This is a duplicate of the first Task, except that instead of running against pull requests,
+# it runs against master and reference pushes only.
+# That's to avoid having duplicated runs against pull requests as me and Julian are pushing to the upstream repo,
+# it creates many pushes.
+# We have to duplicate the task completely as `extra.github.events` branch filtering can't be applied "per github event"
+  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    retries: 0
+    # scopes and routes are necessary for the decision task
+    # in order to allow creationg tasks using these priviledges
+    scopes:
+      - "queue:route:index.project.devtools.*"
+      - "queue:create-task:aws-provisioner-v1/github-worker"
+      - "queue:create-task:aws-provisioner-v1/win2012r2"
+    routes:
+      - "index.project.devtools.branches.{{ event.head.repo.branch }}.*"
+      - "index.project.devtools.revisions.{{ event.head.sha }}.*"
+    extra:
+      github:
+        events:
           - push
+        branches:
+          - master
+          - reference
     payload:
       env:
         GITHUB_HEAD_USER_EMAIL: "{{ event.head.user.email }}"


### PR DESCRIPTION
For now, taskcluster get run twice for pull requests.
That's because we push on upstream. so having `push` and `pull_request` as events to trigger taskcluster, creates one push when we push our branch to ochameau/ff-dt *and* one for the pull request we open.

Unfortunately, I don't think Taskcluster support filtering per event *and* per branch at the same time,
so that I had to duplicate the task definition in `.taskcluster.yml`.
This duplication can later be removed once we have an upstream with just the release branches.