### PR TITLE
Allow to run taskcluster tasks against all pull requests.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,4 +1,7 @@
 version: 0
+# Allow these tasks to run against any pull request,
+# i.e. even people that aren't part of this repo team.
+allowPullRequests: public
 metadata:
   name: devtools
   description: "Firefox Developer Tools"


### PR DESCRIPTION
This flag will be sensible later, when the tasks can do operations with privileges, like signing the add-on or uploading it to some secured hosting.
For now the tasks just execute tests and build an unsigned add-on.