### PR TITLE
Automatically sign the add-on via AMO and push it to archive.mozilla.org

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -17,6 +17,8 @@ tasks:
       - "queue:route:index.project.devtools.*"
       - "queue:create-task:aws-provisioner-v1/github-worker"
       - "queue:create-task:aws-provisioner-v1/win2012r2"
+      - "github:create-status:ochameau/ff-dt"
+      - "github:create-comment:ochameau/ff-dt"
     routes:
       - "index.project.devtools.branches.{{ event.head.repo.branch }}.*"
       - "index.project.devtools.revisions.{{ event.head.sha }}.*"
@@ -65,6 +67,9 @@ tasks:
       - "queue:route:index.project.devtools.*"
       - "queue:create-task:aws-provisioner-v1/github-worker"
       - "queue:create-task:aws-provisioner-v1/win2012r2"
+      - "github:create-status:ochameau/ff-dt"
+      - "github:create-comment:ochameau/ff-dt"
+      - "secrets:get:repo:github.com/ochameau/ff-dt:branch:master"
     routes:
       - "index.project.devtools.branches.{{ event.head.repo.branch }}.*"
       - "index.project.devtools.revisions.{{ event.head.sha }}.*"

--- a/bin/jwt.sh
+++ b/bin/jwt.sh
@@ -1,0 +1,60 @@
+#/bin/bash
+
+# Helper script to handle JWT (JSON Web Tokens)
+# https://jwt.io/
+#
+# Depends on jq, openssl and bc
+
+# Safe default error handling for bash script, more info here:
+# https://sipb.mit.edu/doc/safe-shell/
+set -euo pipefail
+
+if [ -z $AMO_USER ]; then
+  echo "$0 expects AMO_USER env variable to be set"
+  exit
+fi
+if [ -z $AMO_SECRET ]; then
+  echo "$0 expects AMO_SECRET env variable to be set"
+  exit
+fi
+
+IFS=$'\n\t'
+
+HEADER='{
+  "alg": "HS256",
+  "typ": "JWT"
+}'
+PAYLOAD='{
+  "iss": "'$AMO_USER'",
+  "jti": '$(echo "scale=10; $RANDOM*10/32767" | bc)',
+  "iat": '$(date +%s)',
+  "exp": '$(($(date +%s)+60))'
+}'
+
+function base64_encode()
+{
+  declare INPUT=${1:-$(</dev/stdin)};
+  echo -n "$INPUT" | openssl enc -base64 | tr '+\/' '-_' | tr -d '=' | tr -d '\r\n'
+}
+
+# For some reason, probably bash-related, JSON that terminates with an integer
+# must be compacted. So it must be something like `{"userId":1}` or else the
+# signing gets screwed up. Weird, but using `jq -c` works to fix that.
+function json_compact() {
+  declare INPUT=${1:-$(</dev/stdin)};
+  echo -n "$INPUT" | jq -c .
+}
+
+function hmacsha256_sign()
+{
+  declare INPUT=${1:-$(</dev/stdin)};
+  echo -n "$INPUT" | openssl dgst -binary -sha256 -hmac "$AMO_SECRET"
+}
+
+HEADER_BASE64=$(echo "${HEADER}" | json_compact | base64_encode)
+PAYLOAD_BASE64=$(echo "${PAYLOAD}" | json_compact | base64_encode)
+
+HEADER_PAYLOAD=$(echo "${HEADER_BASE64}.${PAYLOAD_BASE64}")
+SIGNATURE=$(echo "${HEADER_PAYLOAD}" | hmacsha256_sign | base64_encode)
+
+echo "${HEADER_PAYLOAD}.${SIGNATURE}"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+# Ensure NOT printing commands
+set +x
+
+# /!\ This script handles private keys /!\
+# Be careful to not leak them and only execute this
+# on safe branch, controlled by core contributors only.
+#
+# Otherwise, this script signs the add-on via AMO
+# and then pushes it to S3 to appear on archive.mozilla.org
+# Secrets are managed on this page:
+# https://tools.taskcluster.net/secrets/
+
+SCRIPT_DIR=$(dirname $0)
+
+# Import AMO credentials from taskcluster secrets
+# only master branch can access them to prevent unauthorized contributors
+# accessing them via pull requests
+export secret_url="http://taskcluster/secrets/v1/secret/repo:github.com/ochameau/ff-dt:branch:master"
+export AMO_USER=$(curl ${secret_url} | jq ".secret.AMO_USER" -r)
+export AMO_SECRET=$(curl ${secret_url} | jq ".secret.AMO_SECRET" -r)
+
+# Append a unique (at least if we don't push twice per minute to master branch...)
+# version prefix to the addon id as AMO requires new addon version for every upload
+# and also require it to be greater.
+# /!\ this changes install.rdf without commiting it.
+VERSION_SUFFIX=$(date +%Y%m%d%H%M)
+sed -i -E 's/em:version=\"([0-9.ab-]+)\"/em:version=\"\1.'$VERSION_SUFFIX'\"/g' install.rdf
+
+$SCRIPT_DIR/build-xpi.sh
+# Note that sign.sh is downloading the xpi from AMO
+# we may just hand over AMO link to github...
+$SCRIPT_DIR/sign.sh devtools.xpi
+
+# If we don't push to S3, we can expose a stable taskcluster api like this:
+# This URL is based on the route declared in taskcluster.yml or task-definitions.yml
+# ROUTE=project.devtools.revisions.$GITHUB_HEAD_REPO_SHA.sign
+# ADDON_URL=https://index.taskcluster.net/v1/task/$ROUTE/artifacts/public/devtools-signed.xpi
+
+# Upload the xpi to S3
+export AWS_ACCESS_KEY_ID=$(curl ${secret_url} | jq ".secret.AWS_ACCESS_KEY_ID" -r)
+export AWS_SECRET_ACCESS_KEY=$(curl ${secret_url} | jq ".secret.AWS_SECRET_ACCESS_KEY" -r)
+S3_ROOT_PATH="/pub/labs/devtools/master"
+S3_BASE_URL="s3://net-mozaws-prod-delivery-contrib$S3_ROOT_PATH"
+aws s3 cp devtools-signed.xpi $S3_BASE_URL/devtools.xpi
+ADDON_URL="https://archive.mozilla.org/pub/labs/devtools/master/devtools.xpi"
+
+# Post a commit status message to github with a link to the signed add-on
+URL="http://taskcluster/github/v1/repository/ochameau/ff-dt/statuses/$GITHUB_HEAD_REPO_SHA"
+JSON="{\"state\":\"success\", \"description\":\"Signed add-on\", \"target_url\": \"$ADDON_URL\", \"context\": \"add-on\"}"
+curl $URL -H "Content-Type: application/json" -X POST -d "$JSON"

--- a/bin/sign.sh
+++ b/bin/sign.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+# This script uses AMO (addons.mozilla.org) API
+# to upload devtools add-on and get it signed.
+
+XPI=$1
+if [[ -z $XPI || ! -f $XPI ]]; then
+  echo "$0 expects path to xpi as first argument"
+  exit
+fi
+if [[ ! -x $(command -v jq) ]]; then
+  echo "$0 requires 'jq' to be installed"
+  exit
+fi
+if [[ ! -x $(command -v openssl) ]]; then
+  echo "$0 requires 'openssl' to be installed"
+  exit
+fi
+if [ -z $AMO_USER ]; then
+  echo "$0 expects AMO_USER env variable to be set"
+  exit
+fi
+if [ -z $AMO_SECRET ]; then
+  echo "$0 expects AMO_SECRET env variable to be set"
+  exit
+fi
+SCRIPT_DIR=$(dirname $0)
+
+VERSION=$(unzip -c $XPI install.rdf | grep em:version | grep -oE "[0-9.ab-]+")
+
+echo "Addon version: $VERSION"
+
+echo "Uploading xpi to sign"
+JWT=$($SCRIPT_DIR/jwt.sh)
+UPLOAD=$(curl "https://addons.mozilla.org/api/v3/addons/devtools@mozilla.org/versions/$VERSION/" \
+  -g -XPUT --form "upload=@$XPI" \
+  -H "Authorization: JWT $JWT")
+echo $UPLOAD
+UPLOAD_URL=$(echo -n $UPLOAD | jq .url -r)
+echo $UPLOAD_URL
+
+# wait a bit for the addon to be available after upload
+sleep 10
+
+# Number of attempts to look for the addon url
+MAX_STEPS=20
+i=0
+while true; do
+  if [ $i -gt $MAX_STEPS ]; then
+      echo "No files found, exiting"
+      exit 1
+  fi
+  i=$(expr $i + 1)
+  echo "Fetch signed xpi URL"
+  JWT=$($SCRIPT_DIR/jwt.sh)
+  UPLOAD_STATUS=$(curl $UPLOAD_URL -g -H "Authorization: JWT $JWT")
+  echo $UPLOAD_STATUS
+  FILE=$(echo -n $UPLOAD_STATUS | jq .files[0].download_url -r)
+  echo $FILE
+  # The addon may still not be ready, so check if we got the url
+  if [ "$FILE" != "null" ]; then
+    break
+  fi
+  sleep 5
+done
+
+echo "Downloading signed xpi"
+JWT=$($SCRIPT_DIR/jwt.sh)
+curl -o devtools-signed.xpi $FILE -g -H "Authorization: JWT $JWT"

--- a/bin/taskcluster/task-definitions.yml
+++ b/bin/taskcluster/task-definitions.yml
@@ -131,19 +131,33 @@ windows:
     name: devtools-windows-opt
     description: "Run tests of DevTools on windows"
 
-after-checks:
+sign:
+# Only sign'n release the addon if linux test pass
+# debug is still unstable as well as windows
   dependencies:
-    - windows
     - linux-opt
-    - linux-debug
+# This can only be done for master branch
+  only-branches:
+    - master
+  scopes:
+    - "github:create-status:ochameau/ff-dt"
+    - "github:create-comment:ochameau/ff-dt"
+    - "secrets:get:repo:github.com/ochameau/ff-dt:branch:master"
   payload:
     maxRunTime: 600
     image: rail/python-test-runner
+# taskclusterProxy is required to query TC for fetching secret and create commit status message
+    features:
+      taskclusterProxy: true
     command:
       - "/bin/bash"
       - "-cx"
       - >
-        ls
+        git clone $GITHUB_HEAD_REPO_URL -q --depth 1 --branch $GITHUB_HEAD_REPO_BRANCH devtools &&
+        cd devtools &&
+        git checkout -q $GITHUB_HEAD_REPO_SHA &&
+        apt-get install -qy jq openssl p7zip-full bc unzip curl awscli &&
+        ./bin/release.sh
   metadata:
-    name: devtools-after-tests
-    description: "Update artifacts if tests succeeded"
+    name: sign
+    description: "Sign the add-on and release it if test succeeded"

--- a/bin/taskcluster/task_decision.js
+++ b/bin/taskcluster/task_decision.js
@@ -24,6 +24,20 @@ function createTask(name, yml) {
       typeof(yml.metadata.description) != "string") {
     throw new Error("Task defined in yml file have to define the `metadata` object with name and description attriutes");
   }
+  if (yml.scopes && !Array.isArray(yml.scopes)) {
+    throw new Error("'scopes' in task defined in yml file should be an array");
+  }
+  if (yml["only-branches"]) {
+    let branches = yml["only-branches"];
+    if (!Array.isArray(branches)) {
+      throw new Error("'only-branches' in task defined in yml file should be an array");
+    }
+    let branch = process.env.GITHUB_HEAD_REPO_BRANCH;
+    if (!branches.includes(branch)) {
+      console.log("Prevent running", name, "task on branch", branch, "by following only-branches attribute");
+      return;
+    }
+  }
 
   let dependencies = [process.env.TASK_ID];
 
@@ -77,6 +91,8 @@ function createTask(name, yml) {
       "index.project.devtools.branches." + process.env.GITHUB_HEAD_REPO_BRANCH + "." + name,
       "index.project.devtools.branches." + process.env.GITHUB_HEAD_REPO_SHA + "." + name
     ],
+
+    scopes:         yml.scopes,
 
     payload:        yml.payload,
 


### PR DESCRIPTION
Sorry, this is a lot of bash again, but that is a very useful part.
This wil take every push of master branch,
build the addon,
upload it to AMO to sign it with a regular signature (good for FF56, bad for FF57),
download the signed add-on from AMO and push it to S3 in order to make it appear on archive.mozilla.org.

It allows me to update my gecko patch on https://bugzilla.mozilla.org/show_bug.cgi?id=1361080
to use a stable URL with a signed addon and finalize that patch.

We can always change things after that. Sign it via another service, upload it somewhere else...
But that setup demonstrate a way to self sign and host the add-on.
This setup should be similar to what some test pilots add-ons are doing and is close to what is done for adbhelper/valence.