### PR TITLE
Push update.rdf to support self-hosted updates.

### DIFF
--- a/bin/template-update.rdf
+++ b/bin/template-update.rdf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+<Description about="urn:mozilla:extension:devtools@mozilla.org">
+<em:updates><Seq><li>
+  <Description>
+    <em:version>@@ADDON_VERSION@@</em:version>
+    <em:targetApplication>
+      <Description>
+        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+        <em:minVersion>53.0a1</em:minVersion>
+        <em:maxVersion>*</em:maxVersion>
+        <em:updateLink>@@UPDATE_LINK@@</em:updateLink>
+      </Description>
+    </em:targetApplication>
+  </Description>
+</li></Seq></em:updates>
+</Description>
+</RDF>

--- a/install.rdf
+++ b/install.rdf
@@ -13,6 +13,7 @@
                em:description="Add-on to load DevTools from local sources and easily reload them with Ctrl+Alt+r shortcut"
                em:version="44.0a1"
                em:type="2"
+               em:updateURL="https://archive.mozilla.org/pub/labs/devtools/master/update.rdf"
                em:creator="Mozilla">
 
     <em:bootstrap>true</em:bootstrap>


### PR DESCRIPTION
Uses same setup we were using for adbhelper.
It would surely help to avoid hardcoding the updateURL in the install.rdf...

So the xpi should live here:
  https://archive.mozilla.org/pub/labs/devtools/master/devtools.xpi
  The install.rdf in this xpi is now going to refer to the following url:
The update.rdf here:
  https://archive.mozilla.org/pub/labs/devtools/master/update.rdf

We can easily introduce some folders, and duplicate all these devtools.xpi and update.rdf to help supporting old releases. One folder per Firefox release
https://archive.mozilla.org/pub/labs/devtools/{56,57,58,...}/{devtools,update}.rdf
`release.sh` would only update the current nightly, beta and release folders and stop updating all the older.
(Note that s3 doesn't support symlink from what I remember so we have to push the same copy multiple times)

I pushed it to master to verify it works and made a copy over `master-update-demo` (in case auto-updater overrides master in the meantime).